### PR TITLE
Add default tenantId

### DIFF
--- a/phasezero/core.py
+++ b/phasezero/core.py
@@ -67,27 +67,6 @@ def download_file(session, project_id, key):
     result = session.get_stream(url_endpoint)
     return result
 
-def get_images_base64():
-    """
-    Gets image from a document as a base64 encoded string
-    :param document_id:
-    :param session: phasezero.session.Session
-    :return: list of Projects
-    """
-    jwtToken = ""
-    url = "https://api.phasezerotrials.com/1.0/Documents/1d899d37-e253-4923-bf8c-65989bd6b6df/Url"
-    headers = {
-        "accept": "application/json",
-        "Content-Type": "application/json",
-        "Authorization": "Bearer " + jwtToken
-    }
-
-    presigned_url = requests.get(url, headers=headers).json()
-    response = requests.get(presigned_url)
-    print(response.content)
-
-
-
 def initiate_multipart_upload(session, document_id):
     """
     Gets all Projects visible to the authenticated user

--- a/phasezero/core.py
+++ b/phasezero/core.py
@@ -1,4 +1,6 @@
+import requests
 import six
+import base64
 from phasezero.session import simplify_response
 import urllib
 
@@ -64,6 +66,26 @@ def download_file(session, project_id, key):
 
     result = session.get_stream(url_endpoint)
     return result
+
+def get_images_base64():
+    """
+    Gets image from a document as a base64 encoded string
+    :param document_id:
+    :param session: phasezero.session.Session
+    :return: list of Projects
+    """
+    jwtToken = ""
+    url = "https://api.phasezerotrials.com/1.0/Documents/1d899d37-e253-4923-bf8c-65989bd6b6df/Url"
+    headers = {
+        "accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + jwtToken
+    }
+
+    presigned_url = requests.get(url, headers=headers).json()
+    response = requests.get(presigned_url)
+    print(response.content)
+
 
 
 def initiate_multipart_upload(session, document_id):

--- a/phasezero/core.py
+++ b/phasezero/core.py
@@ -1,6 +1,3 @@
-import requests
-import six
-import base64
 from phasezero.session import simplify_response
 import urllib
 
@@ -66,6 +63,7 @@ def download_file(session, project_id, key):
 
     result = session.get_stream(url_endpoint)
     return result
+
 
 def initiate_multipart_upload(session, document_id):
     """

--- a/phasezero/session.py
+++ b/phasezero/session.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-DEFAULT_HOST = 'https://localhost:5001'
+DEFAULT_HOST = 'https://api.phasezerotrials.com'
 LOGIN_ENDPOINT = DEFAULT_HOST + '/1.0/Auth/login'
 
 


### PR DESCRIPTION
<img width="926" alt="image" src="https://user-images.githubusercontent.com/10590332/181267708-7b505f24-0da9-4cd5-8cd0-18dff3153edc.png">

The Auth Changes in this [PR](https://github.com/PhaseZeroTrials/phasezero-api/pull/249) introduces a `X-Tenant-Id` header

This PR updates the Python CLI to pass in the `X-Tenant-Id` header