### PR TITLE
[Develop -> Master] Reduce login calls during parallel uploads

### DIFF
--- a/phasezero/session.py
+++ b/phasezero/session.py
@@ -166,9 +166,7 @@ class Session(object):
         return simplify_response(r.json())
 
     def _get(self, path, **kwargs):
-        r = self.session.get(self.make_url(path), verify=False, **kwargs)
-        r.raise_for_status()
-        return r
+        return self._do_request(self.session.get, path, **kwargs)
 
     def put(self, path, data=None, **kwargs):
         """
@@ -188,9 +186,7 @@ class Session(object):
         return simplify_response(r.json())
 
     def _put(self, path, **kwargs):
-        r = self.session.put(self.make_url(path), verify=False, **kwargs)
-        r.raise_for_status()
-        return r
+        return self._do_request(self.session.put, path, **kwargs)
 
     def post(self, path, data=None, **kwargs):
         if data is None:
@@ -202,15 +198,20 @@ class Session(object):
         return simplify_response(r.json())
 
     def _post(self, path, **kwargs):
-        r = self.session.post(self.make_url(path), verify=False, **kwargs)
-        r.raise_for_status()
-        return r
+        return self._do_request(self.session.post, path, **kwargs)
 
     def delete(self, path, **kwargs):
         return self.retry_call(self._delete, path, **kwargs)
 
     def _delete(self, path, **kwargs):
-        r = self.session.delete(self.make_url(path), verify=False, **kwargs)
+        return self._do_request(self.session.delete, path, **kwargs)
+
+    def _do_request(self, method, path, **kwargs):
+        url = self.make_url(path)
+        r = method(url, verify=False, **kwargs)
+        if r.status_code == 401:
+            self.refresh_token()
+            r = method(url, verify=False, **kwargs)
         r.raise_for_status()
         return r
 

--- a/phasezero/upload.py
+++ b/phasezero/upload.py
@@ -147,9 +147,6 @@ def multipart_upload_to_aws(session, document, content_type, local_path, progres
     params = {'uploadId': document['uploadId']}
     encoded_params = urllib.parse.urlencode(params)
 
-    # Mark upload as complete
-    # Refresh in case of time out
-    session.refresh_token()
     session.put(f"{mark_as_complete_endpoint}?{encoded_params}", parts)
 
 


### PR DESCRIPTION
# Reduce login calls during parallel uploads

## Summary
- Stop calling `Session.refresh_token()` (which posts to `/1.0/Auth/login`) on every multipart upload completion in `multipart_upload_to_aws`.
- Add a single 401-aware retry layer to `Session._get/_put/_post/_delete`: if the server returns 401, refresh the token once and retry the same request before raising.

## Why
A user reported intermittent `Unable to connect due to a server error` while running parallel CLI uploads of many files. We traced the production API outage to a login storm against `/1.0/Auth/login` — 1,000+ logins in 30 minutes from a single user. Each storm killed prod ECS tasks one by one because `/1.0/Health` requests were timing out behind starved worker threads.

The cause was on the client side: `multipart_upload_to_aws` called `session.refresh_token()` right before the `Mark Complete` request on every file. A multi-file parallel upload therefore did one full email+password login per file. Cognito tokens are valid for ~1h, so this was almost always wasted work — and under load it triggered the very "server error" message the comment said it was protecting against.

## What changed

**`phasezero/upload.py`**
- Removed the unconditional `session.refresh_token()` call before posting `Revision`. The session token from `connect()` covers the duration of the upload.

**`phasezero/session.py`**
- New `_do_request(method, path, **kwargs)` helper:
  - issues the request,
  - on `401`, calls `refresh_token()` exactly once and retries the same request,
  - then `raise_for_status()`.
- `_get/_put/_post/_delete` now delegate to `_do_request` instead of duplicating the request/`raise_for_status` pattern.

The existing `retry_call` exponential-backoff layer is unchanged, so transient 5xx behavior is identical.

## Behavior change for callers
- A CLI run that uploads N files in parallel now performs **1 login** at session start (and at most 1 refresh per request that actually sees a 401), instead of N+ logins.
- No public API change. Callers don't need to update.

