### PR TITLE
Gracefully handle rate limiting (HTTP 429)

### DIFF
--- a/phasezero/session.py
+++ b/phasezero/session.py
@@ -1,4 +1,5 @@
 import collections
+import time
 import six
 import requests
 import retrying
@@ -211,6 +212,15 @@ class Session(object):
         r = method(url, verify=False, **kwargs)
         if r.status_code == 401:
             self.refresh_token()
+            r = method(url, verify=False, **kwargs)
+        elif r.status_code == 429:
+            try:
+                retry_after = int(r.headers.get('Retry-After', '60'))
+            except (TypeError, ValueError):
+                retry_after = 60
+            retry_after = max(1, min(retry_after, 300))
+            print(f"Rate limited. Waiting {retry_after}s before retry…")
+            time.sleep(retry_after)
             r = method(url, verify=False, **kwargs)
         r.raise_for_status()
         return r


### PR DESCRIPTION
# Gracefully handle rate limiting (HTTP 429)

## Summary
Honor server-side rate limits in `Session._do_request`: on a `429`, sleep for the `Retry-After` header value and retry the request once before raising.

## Why
The API now applies a per-IP rate limit on `/1.0/Auth/login` at the WAF (30 req / 60s, returns `429` with `Retry-After: 60`). Without explicit handling on the client, a `429` flows through `raise_for_status()` and gets caught by the existing `retry_call` exponential-backoff wrapper — but that wrapper caps wait time at 2s, so a parallel uploader would burn its 4 retries inside the 60s rate-limit window and surface a hard failure to the user instead of just waiting it out.

## What changed

**`phasezero/session.py`**
- `_do_request` now treats `429` similarly to how it treats `401`:
  - read `Retry-After` from the response (default 60s, clamped to 1–300s),
  - `time.sleep(retry_after)`,
  - retry the same request once,
  - then `raise_for_status()`.
- A short `Rate limited. Waiting Ns before retry…` message is printed so users running long parallel uploads can see what's happening.

The 401 branch is unchanged. The outer `retry_call` exponential-backoff layer is unchanged. 429 is handled inside `_do_request` rather than in the retry wrapper because the wrapper's 2s exponential cap is too short for a 60s bucket — letting it through would just busy-loop against a closed bucket.

## Behavior change for callers
- A request that hits a 429 will block the calling thread for up to ~60s while the bucket refills, then continue. Previously it would raise `HTTPError` after a few quick retries.
- No public API change. Callers don't need to update.

