### PR TITLE
Add jitter to 429 retry

### DIFF
--- a/phasezero/session.py
+++ b/phasezero/session.py
@@ -1,4 +1,5 @@
 import collections
+import random
 import time
 import six
 import requests
@@ -219,8 +220,10 @@ class Session(object):
             except (TypeError, ValueError):
                 retry_after = 60
             retry_after = max(1, min(retry_after, 300))
-            print(f"Rate limited. Waiting {retry_after}s before retry…")
-            time.sleep(retry_after)
+            jitter = random.uniform(0, retry_after * 0.25)
+            wait = retry_after + jitter
+            print(f"Rate limited. Waiting {wait:.1f}s before retry…")
+            time.sleep(wait)
             r = method(url, verify=False, **kwargs)
         r.raise_for_status()
         return r


### PR DESCRIPTION
# Add jitter to 429 retry sleep

## Summary
When `Session._do_request` sleeps in response to a `429`, add 0–25% random jitter to the `Retry-After` value before sleeping.

## Why
The previous change (#24) made the CLI sleep for exactly the server's `Retry-After` (defaults to 60s) on a `429`. That fixes the busy-loop case, but introduces a thundering-herd: if 50 parallel uploads all get rate-limited within the same window, they each sleep the same 60s and all wake at the same instant, immediately re-saturating the bucket.

Jittering each retry by 0–25% spreads the wakeups across a 15s spread, so the 60-req/min bucket refills smoothly instead of getting hammered in a single burst.

## What changed

**`phasezero/session.py`**
- Added `import random`.
- In `_do_request`'s `429` branch, sleep for `retry_after + uniform(0, retry_after * 0.25)` instead of just `retry_after`.
- The console message now prints the jittered wait (e.g. `Waiting 67.3s before retry…`) so users can see the actual sleep duration.

No public API change. The 401 branch and the outer `retry_call` exponential-backoff layer are untouched.

## Test plan
- [ ] Mock a `429` with `Retry-After: 60` and confirm sleep duration is in `[60, 75]` seconds.
- [ ] Run a parallel upload of >30 files against an endpoint with a 60-req/min limit; confirm CLI logs show staggered "Waiting Ns…" messages rather than all firing at the same second.
- [ ] Confirm a single-threaded run still completes (no regression on the happy path).
