### PR TITLE
Skip already-uploaded files in `upload_folder`

### DIFF
--- a/phasezero/upload.py
+++ b/phasezero/upload.py
@@ -36,7 +36,20 @@ class ProgressPercentage(object):
                 self._progress.close()
 
 
-def upload_folder(session, project_id, project_path, directory_path, failed_files, progress=tqdm):
+def _already_uploaded(session, project_id, project_path, name):
+    """
+    Returns True if a document at this project path already has a completed
+    revision on the server. Used to skip files when resuming a partial upload.
+    """
+    try:
+        existing = core.get_file(session, project_id, project_path, name)
+    except Exception:
+        return False
+    return bool(existing) and bool(existing.get('currentVersion'))
+
+
+def upload_folder(session, project_id, project_path, directory_path, failed_files,
+                  progress=tqdm, skip_existing=True):
     """
     Recursively uploads a folder to Phase Zero
 
@@ -46,6 +59,8 @@ def upload_folder(session, project_id, project_path, directory_path, failed_file
     :param directory_path: local path to directory
     :param failed_files: list of files failed to be uploaded
     :param progress: if not None, wrap in a progress (i.e. tqdm). Default: tqdm
+    :param skip_existing: if True (default), files that already have a completed
+        revision on the server are skipped. Lets you resume a partial upload.
     """
     directory_path = os.path.abspath(directory_path)  # ensure full path
 
@@ -56,6 +71,11 @@ def upload_folder(session, project_id, project_path, directory_path, failed_file
 
         for f in files:
             local_file_path = os.path.join(root, f)
+
+            if skip_existing and _already_uploaded(session, project_id, relative_path, f):
+                print(f"Skipping {local_file_path} (already uploaded)")
+                continue
+
             try:
                 file = core.create_file(session, project_id, relative_path, f)
             except:


### PR DESCRIPTION

# Skip already-uploaded files in `upload_folder`

## Why

Large folder uploads (thousands of files / many GB) can be interrupted partway
through — a network blip, a kill, a 429 burst that exhausts retries, etc.
Today there's no way to resume; you have to either re-run the whole thing
(which re-uploads everything from scratch) or manually figure out which files
already made it.

A real customer just hit this with a multi-thousand-file upload, so adding a
resume path is worth doing.

## What

`upload_folder` now takes a `skip_existing=True` parameter. Before each file,
we check the server with `core.get_file(...)` and skip if there's already a
document at that path with a `currentVersion` set (i.e. a completed revision).

A new `_already_uploaded` helper does the lookup and swallows exceptions, so
a missing file or a transient API blip just falls through to the normal
create/upload path — no behavior change in the unhappy case.

Re-running the same `upload_folder(...)` call now picks up roughly where it
left off instead of restarting from zero.

## Notes

- Default is `skip_existing=True`. If a caller wants the old behavior (always
  re-upload), they can pass `skip_existing=False`.
- The check is one extra `GET /Documents/Study/{id}/Path/{path}` per file.
  For very large folders that's not free, but it's cheap compared to the
  upload itself, and it's the same endpoint we'd hit on the create-fail path
  anyway.
- Skip is name-based, not content-based. If a file changed locally but the
  server already has a completed revision at that path, it'll be skipped.
  Fine for resume; not a sync tool.